### PR TITLE
Update sitemap-static paths

### DIFF
--- a/app/sitemap-static.xml/route.js
+++ b/app/sitemap-static.xml/route.js
@@ -6,6 +6,9 @@ export async function GET() {
       '/conciergerie',
       '/mentions-legales',
       '/politique-de-confidentialite',
+      '/blog',
+      '/repertoire',
+      '/seminaires',
     ];
   
     const urls = staticPaths.map(path => `
@@ -23,4 +26,3 @@ export async function GET() {
       { headers: { 'Content-Type': 'application/xml' } }
     );
   }
-  


### PR DESCRIPTION
## Summary
- include blog, repertoire and seminaires paths in `app/sitemap-static.xml/route.js`

## Testing
- `node -e "import('./app/sitemap-static.xml/route.js').then(async m => {process.env.SITE_URL='https://example.com'; const resp = await m.GET(); resp.text().then(t => console.log(t));});" | grep -E '(/blog|/repertoire|/seminaires)' -n`

------
https://chatgpt.com/codex/tasks/task_e_685c3fa77888832e8b39bddefa5eb129